### PR TITLE
#ZC5r2bWu Parse Excerpt Markdown

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -74,12 +74,14 @@ function add_types_custom_meta($data, $post, $context) {
   return $data;
 }
 
-function parse_excerpt_markdown($data, $post, $context) {
+function parse_excerpt_markdown( $excerpt ) {
   if (class_exists(WPCom_Markdown)) {
-    $markdown_excerpt = WPCom_Markdown::get_instance()->transform( $data['excerpt'] );
-    $data['excerpt'] = stripslashes($markdown_excerpt);
+    $excerpt = WPCom_Markdown::get_instance()->transform( $excerpt );
+    $excerpt = stripslashes($excerpt);
+    $excerpt = wpautop($excerpt);
+    $excerpt = str_replace("\n", "", $excerpt);
   }
-  return $data;
+  return $excerpt;
 }
 
 add_action( 'init', 'register_media_taxonomies' );
@@ -88,7 +90,8 @@ add_action( 'after_setup_theme', 'setup' );
 add_filter( 'login_redirect', 'redirect_to_posts' );
 add_action( 'admin_menu', 'customize_menu', 999 );
 add_filter( 'json_prepare_post', 'add_types_custom_meta', 10, 3 );
-add_filter( 'json_prepare_post', 'parse_excerpt_markdown', 10, 3 );
+remove_filter( 'the_excerpt', 'wpautop' ); // Remove this and apply in parse_excerpt_markdown
+add_filter( 'get_the_excerpt', 'parse_excerpt_markdown' );
 
 if( class_exists( WpeCommon ) ){
   require 'wpengine.php';

--- a/functions.php
+++ b/functions.php
@@ -4,82 +4,82 @@
 $content_width = 90000; // pixels
 
 function getRedirect() {
-    $url  = $_SERVER["SERVER_NAME"];
-    $url .= $_SERVER["REQUEST_URI"];
+  $url  = $_SERVER["SERVER_NAME"];
+  $url .= $_SERVER["REQUEST_URI"];
 
-    $redirect = preg_replace("/^(.*?)\.(.*)$/","$2", $url);
+  $redirect = preg_replace("/^(.*?)\.(.*)$/","$2", $url);
 
-    return 'http://'.$redirect;
+  return 'http://'.$redirect;
 }
 
 function setup(){
-	// Enable support for Post Thumbnails on posts and pages
-	add_theme_support( 'post-thumbnails' );
+  // Enable support for Post Thumbnails on posts and pages
+  add_theme_support( 'post-thumbnails' );
 
-	// Enable support for Post Formats
-	add_theme_support( 'post-formats', array( 'image', 'quote', 'link', 'chat', 'audio', 'video' ) );
+  // Enable support for Post Formats
+  add_theme_support( 'post-formats', array( 'image', 'quote', 'link', 'chat', 'audio', 'video' ) );
 }
 
 function register_media_taxonomies(){
-	// Enable category/tag taxonomies for media attachments
-    register_taxonomy_for_object_type( 'category', 'attachment' );
-    register_taxonomy_for_object_type( 'post_tag', 'attachment' );
+  // Enable category/tag taxonomies for media attachments
+  register_taxonomy_for_object_type( 'category', 'attachment' );
+  register_taxonomy_for_object_type( 'post_tag', 'attachment' );
 }
 
 function add_markdown_support() {
-    if (function_exists(jetpack_require_lib)) {
-        jetpack_require_lib( 'markdown' );
-    }
+  if (function_exists(jetpack_require_lib)) {
+    jetpack_require_lib( 'markdown' );
+  }
 }
 
 function api_url(){
-    wp_redirect( 'http://wp-api.org' );
+  wp_redirect( 'http://wp-api.org' );
 }
 
 function redirect_to_posts($url) {
-    return '/wp-admin/edit.php';
+  return '/wp-admin/edit.php';
 }
 
 function customize_menu(){
-    // http://justintadlock.com/archives/2011/06/13/removing-menu-pages-from-the-wordpress-admin
-    remove_menu_page('index.php');
-    remove_menu_page('edit-comments.php');
-    remove_menu_page('themes.php');
-    remove_menu_page('tools.php');
-    remove_menu_page('edit.php?post_type=feedback');
+  // http://justintadlock.com/archives/2011/06/13/removing-menu-pages-from-the-wordpress-admin
+  remove_menu_page('index.php');
+  remove_menu_page('edit-comments.php');
+  remove_menu_page('themes.php');
+  remove_menu_page('tools.php');
+  remove_menu_page('edit.php?post_type=feedback');
 
-    // http://codex.wordpress.org/Function_Reference/add_menu_page
-    add_menu_page( 'API', 'API', 'activate_plugins', 'api', 'api_url', 'dashicons-admin-links', '20.1' );
+  // http://codex.wordpress.org/Function_Reference/add_menu_page
+  add_menu_page( 'API', 'API', 'activate_plugins', 'api', 'api_url', 'dashicons-admin-links', '20.1' );
 }
 
 // Add custom fields created by Types plugin to public types_custom_meta key
 function add_types_custom_meta($data, $post, $context) {
-    if (function_exists(types_get_fields_by_group)) {
-        $post_custom_data = get_post_custom( $post['ID'] );
+  if (function_exists(types_get_fields_by_group)) {
+    $post_custom_data = get_post_custom( $post['ID'] );
 
-        // Get a list of Types custom fields in the "public" group
-        $public_types_fields = types_get_fields_by_group('public');
+    // Get a list of Types custom fields in the "public" group
+    $public_types_fields = types_get_fields_by_group('public');
 
-        foreach ( $post_custom_data as $key => $value ) {
-            if ( in_array($key, array_keys($public_types_fields)) || in_array(substr($key, 5), array_keys($public_types_fields)) ) {
-                $types_custom_meta[$key] = $value;
-            }
-        }
-
-        if ( !empty($types_custom_meta) ) {
-            $data['types_custom_meta'] = $types_custom_meta;
-        }
+    foreach ( $post_custom_data as $key => $value ) {
+      if ( in_array($key, array_keys($public_types_fields)) || in_array(substr($key, 5), array_keys($public_types_fields)) ) {
+        $types_custom_meta[$key] = $value;
+      }
     }
 
-    return $data;
+    if ( !empty($types_custom_meta) ) {
+      $data['types_custom_meta'] = $types_custom_meta;
+    }
+  }
+
+  return $data;
 }
 
 function parse_excerpt_markdown($data, $post, $context) {
-    if (class_exists(WPCom_Markdown)) {
-        $markdown_excerpt = WPCom_Markdown::get_instance()->transform( $data['excerpt'] );
-        $data['excerpt'] = stripslashes($markdown_excerpt);
-    }
-    return $data;
+  if (class_exists(WPCom_Markdown)) {
+    $markdown_excerpt = WPCom_Markdown::get_instance()->transform( $data['excerpt'] );
+    $data['excerpt'] = stripslashes($markdown_excerpt);
+  }
+  return $data;
 }
 
 add_action( 'init', 'register_media_taxonomies' );
@@ -91,5 +91,5 @@ add_filter( 'json_prepare_post', 'add_types_custom_meta', 10, 3 );
 add_filter( 'json_prepare_post', 'parse_excerpt_markdown', 10, 3 );
 
 if( class_exists( WpeCommon ) ){
-    require 'wpengine.php';
+  require 'wpengine.php';
 }

--- a/functions.php
+++ b/functions.php
@@ -26,6 +26,12 @@ function register_media_taxonomies(){
     register_taxonomy_for_object_type( 'post_tag', 'attachment' );
 }
 
+function add_markdown_support() {
+    if (function_exists(jetpack_require_lib)) {
+        jetpack_require_lib( 'markdown' );
+    }
+}
+
 function api_url(){
     wp_redirect( 'http://wp-api.org' );
 }
@@ -68,11 +74,21 @@ function add_types_custom_meta($data, $post, $context) {
     return $data;
 }
 
+function parse_excerpt_markdown($data, $post, $context) {
+    if (class_exists(WPCom_Markdown)) {
+        $markdown_excerpt = WPCom_Markdown::get_instance()->transform( $data['excerpt'] );
+        $data['excerpt'] = stripslashes($markdown_excerpt);
+    }
+    return $data;
+}
+
 add_action( 'init', 'register_media_taxonomies' );
+add_action( 'init', 'add_markdown_support' );
 add_action( 'after_setup_theme', 'setup' );
 add_filter( 'login_redirect', 'redirect_to_posts' );
 add_action( 'admin_menu', 'customize_menu', 999 );
 add_filter( 'json_prepare_post', 'add_types_custom_meta', 10, 3 );
+add_filter( 'json_prepare_post', 'parse_excerpt_markdown', 10, 3 );
 
 if( class_exists( WpeCommon ) ){
     require 'wpengine.php';


### PR DESCRIPTION
Clique Tools allowed Markdown formatting in leads and thus these tags have been carried over into the content imported into WordPress as excerpts. But the Jetpack Markdown module we use to parse the content does not apply to the excerpts by default, so this PR adds a filter to parse the excerpt markdown before adding it to the API response.